### PR TITLE
Generalize obj IO using streams, keeping backwards compatibility

### DIFF
--- a/include/tinynurbs/io/obj.h
+++ b/include/tinynurbs/io/obj.h
@@ -26,8 +26,8 @@ namespace internal
 {
 
 /**
- * Read rational curve data from a Wavefront OBJ file.
- * @param filename Name of the file
+ * Read rational curve data from a Wavefront OBJ stream.
+ * @param is The input stream
  * @param[inout] deg Degree of the curve
  * @param[inout] knots Knot vector of the curve
  * @param[inout] ctrlPts Array of control points
@@ -35,7 +35,7 @@ namespace internal
  * @param[inout] rational Whether rational
  */
 template <typename T>
-void curveReadOBJ(const std::string &filename, unsigned int &deg, std::vector<T> &knots,
+void curveReadOBJ(std::istream &is, unsigned int &deg, std::vector<T> &knots,
                   std::vector<glm::vec<3, T>> &ctrlPts, std::vector<T> &weights, bool &rational)
 {
     T knot_min = 0, knot_max = 1;
@@ -47,12 +47,6 @@ void curveReadOBJ(const std::string &filename, unsigned int &deg, std::vector<T>
     std::string start, token, sline;
     std::istringstream ssline;
 
-    std::ifstream file(filename);
-    if (!file)
-    {
-        throw std::runtime_error("File not found: " + filename);
-    }
-
     struct ToParse
     {
         bool deg, cstype, curv, parm;
@@ -60,7 +54,7 @@ void curveReadOBJ(const std::string &filename, unsigned int &deg, std::vector<T>
 
     ToParse parsed;
 
-    while (std::getline(file, sline))
+    while (std::getline(is, sline))
     {
         if (sline.size() == 0)
         {
@@ -114,7 +108,7 @@ void curveReadOBJ(const std::string &filename, unsigned int &deg, std::vector<T>
                 if (token == "\\")
                 {
                     ssline.clear();
-                    getline(file, sline);
+                    getline(is, sline);
                     ssline.str(sline);
                 }
                 else
@@ -134,7 +128,7 @@ void curveReadOBJ(const std::string &filename, unsigned int &deg, std::vector<T>
                     if (token == "\\")
                     {
                         ssline.clear();
-                        std::getline(file, sline);
+                        std::getline(is, sline);
                         ssline.str(sline);
                     }
                     else
@@ -151,9 +145,8 @@ void curveReadOBJ(const std::string &filename, unsigned int &deg, std::vector<T>
         }
         ssline.clear();
     }
-    file.close();
 
-    // Check if necessary data was available in file
+    // Check if necessary data was available in stream
     if (!parsed.cstype)
     {
         throw std::runtime_error("'cstype bspline / cstype rat bspline' line missing in file");
@@ -189,8 +182,8 @@ void curveReadOBJ(const std::string &filename, unsigned int &deg, std::vector<T>
 }
 
 /**
- * Read rational surface data from a Wavefront OBJ file.
- * @param filename Name of the file
+ * Read rational surface data from a Wavefront OBJ stream.
+ * @param is The input stream
  * @param[inout] deg_u Degree of the surface along u-direction
  * @param[inout] deg_v Degree of the surface along u-direction
  * @param[inout] knots_u Knot vector of the surface along u-direction
@@ -200,7 +193,7 @@ void curveReadOBJ(const std::string &filename, unsigned int &deg, std::vector<T>
  * @param[inout] rational Whether rational
  */
 template <typename T>
-void surfaceReadOBJ(const std::string &filename, unsigned int &deg_u, unsigned int &deg_v,
+void surfaceReadOBJ(std::istream &is, unsigned int &deg_u, unsigned int &deg_v,
                     std::vector<T> &knots_u, std::vector<T> &knots_v,
                     array2<glm::vec<3, T>> &ctrlPts, array2<T> &weights, bool &rational)
 {
@@ -216,12 +209,6 @@ void surfaceReadOBJ(const std::string &filename, unsigned int &deg_u, unsigned i
     std::string start, token, sline;
     std::istringstream ssline;
 
-    std::ifstream file(filename);
-    if (!file)
-    {
-        throw std::runtime_error("File not found: " + filename);
-    }
-
     struct ToParse
     {
         bool deg, cstype, surf, parm;
@@ -229,7 +216,7 @@ void surfaceReadOBJ(const std::string &filename, unsigned int &deg_u, unsigned i
 
     ToParse parsed;
 
-    while (std::getline(file, sline))
+    while (std::getline(is, sline))
     {
         if (sline.size() == 0)
         {
@@ -283,7 +270,7 @@ void surfaceReadOBJ(const std::string &filename, unsigned int &deg_u, unsigned i
                 if (token == "\\")
                 {
                     ssline.clear();
-                    getline(file, sline);
+                    getline(is, sline);
                     ssline.str(sline);
                 }
                 else
@@ -303,7 +290,7 @@ void surfaceReadOBJ(const std::string &filename, unsigned int &deg_u, unsigned i
                     if (token == "\\")
                     {
                         ssline.clear();
-                        std::getline(file, sline);
+                        std::getline(is, sline);
                         ssline.str(sline);
                     }
                     else
@@ -319,7 +306,7 @@ void surfaceReadOBJ(const std::string &filename, unsigned int &deg_u, unsigned i
                     if (token == "\\")
                     {
                         ssline.clear();
-                        std::getline(file, sline);
+                        std::getline(is, sline);
                         ssline.str(sline);
                     }
                     else
@@ -336,9 +323,8 @@ void surfaceReadOBJ(const std::string &filename, unsigned int &deg_u, unsigned i
         }
         ssline.clear();
     }
-    file.close();
 
-    // Check if necessary data was available in file
+    // Check if necessary data was available in stream
     if (!parsed.cstype)
     {
         throw std::runtime_error("'cstype bspline / cstype rat bspline' line missing in file");
@@ -380,8 +366,8 @@ void surfaceReadOBJ(const std::string &filename, unsigned int &deg_u, unsigned i
 }
 
 /**
- * Save curve data to a Wavefront OBJ file.
- * @param filename Name of the file
+ * Save curve data to a Wavefront OBJ stream.
+ * @param os The output stream
  * @param deg Degree of the curve
  * @param knots Knot vector of the curve
  * @param ctrlPts Array of control points
@@ -389,16 +375,15 @@ void surfaceReadOBJ(const std::string &filename, unsigned int &deg_u, unsigned i
  * @param rational Whether rational
  */
 template <typename T>
-void curveSaveOBJ(const std::string &filename, unsigned int degree, const std::vector<T> &knots,
+void curveSaveOBJ(std::ostream &os, unsigned int degree, const std::vector<T> &knots,
                   const std::vector<glm::vec<3, T>> &ctrlPts, const std::vector<T> &weights,
                   bool rational)
 {
     using std::endl;
-    std::ofstream fout(filename);
 
     for (int i = 0; i < ctrlPts.size(); ++i)
     {
-        fout << "v " << ctrlPts[i].x << " " << ctrlPts[i].y << " " << ctrlPts[i].z << " "
+        os << "v " << ctrlPts[i].x << " " << ctrlPts[i].y << " " << ctrlPts[i].z << " "
              << weights[i] << endl;
     }
 
@@ -407,30 +392,29 @@ void curveSaveOBJ(const std::string &filename, unsigned int degree, const std::v
 
     if (!rational)
     {
-        fout << "cstype bspline" << endl;
+        os << "cstype bspline" << endl;
     }
     else
     {
-        fout << "cstype rat bspline" << endl;
+        os << "cstype rat bspline" << endl;
     }
-    fout << "deg " << degree << endl << "curv ";
-    fout << knots[degree] << " " << knots[n_knots - degree - 1];
+    os << "deg " << degree << endl << "curv ";
+    os << knots[degree] << " " << knots[n_knots - degree - 1];
     for (int i = 0; i < n_cp; ++i)
     {
-        fout << " " << i + 1;
+        os << " " << i + 1;
     }
-    fout << endl << "parm u";
+    os << endl << "parm u";
     for (auto knot : knots)
     {
-        fout << " " << knot;
+        os << " " << knot;
     }
-    fout << endl << "end";
-    fout.close();
+    os << endl << "end";
 }
 
 /**
- * Save surface data to a Wavefront OBJ file.
- * @param filename Name of the file
+ * Save surface data to a Wavefront OBJ stream.
+ * @param os The output stream
  * @param deg_u Degree of the surface along u-direction
  * @param deg_v Degree of the surface along v-direction
  * @param knots_u Knot vector of the surface along u-direction
@@ -440,13 +424,12 @@ void curveSaveOBJ(const std::string &filename, unsigned int degree, const std::v
  * @param rational Whether rational
  */
 template <typename T>
-void surfaceSaveOBJ(const std::string &filename, unsigned int deg_u, unsigned int deg_v,
+void surfaceSaveOBJ(std::ostream &os, unsigned int deg_u, unsigned int deg_v,
                     const std::vector<T> &knots_u, const std::vector<T> &knots_v,
                     const array2<glm::vec<3, T>> &ctrlPts, const array2<T> &weights, bool rational)
 {
 
     using std::endl;
-    std::ofstream fout(filename);
 
     if (ctrlPts.rows() == 0 || ctrlPts.cols() == 0)
     {
@@ -457,7 +440,7 @@ void surfaceSaveOBJ(const std::string &filename, unsigned int deg_u, unsigned in
     {
         for (int i = 0; i < ctrlPts.rows(); i++)
         {
-            fout << "v " << ctrlPts(i, j).x << " " << ctrlPts(i, j).y << " " << ctrlPts(i, j).z
+            os << "v " << ctrlPts(i, j).x << " " << ctrlPts(i, j).y << " " << ctrlPts(i, j).z
                  << " " << weights(i, j) << endl;
         }
     }
@@ -470,34 +453,108 @@ void surfaceSaveOBJ(const std::string &filename, unsigned int deg_u, unsigned in
 
     if (!rational)
     {
-        fout << "cstype bspline" << endl;
+        os << "cstype bspline" << endl;
     }
     else
     {
-        fout << "cstype rat bspline" << endl;
+        os << "cstype rat bspline" << endl;
     }
-    fout << "deg " << deg_u << " " << deg_v << endl << "surf ";
-    fout << knots_u[deg_u] << " " << knots_u[nknots_u - deg_u - 1] << " " << knots_v[deg_v] << " "
+    os << "deg " << deg_u << " " << deg_v << endl << "surf ";
+    os << knots_u[deg_u] << " " << knots_u[nknots_u - deg_u - 1] << " " << knots_v[deg_v] << " "
          << knots_v[nknots_v - deg_v - 1];
     for (int i = 0; i < nCpU * nCpV; i++)
     {
-        fout << " " << i + 1;
+        os << " " << i + 1;
     }
-    fout << endl << "parm u";
+    os << endl << "parm u";
     for (auto knot : knots_u)
     {
-        fout << " " << knot;
+        os << " " << knot;
     }
-    fout << endl << "parm v";
+    os << endl << "parm v";
     for (auto knot : knots_v)
     {
-        fout << " " << knot;
+        os << " " << knot;
     }
-    fout << endl << "end";
-    fout.close();
+    os << endl << "end";
 }
 
 } // namespace internal
+
+/////////////////////////////////////////////////////////////////////
+
+/**
+ * Read curve data from a Wavefront OBJ stream and populate a RationalCurve object
+ * @param is The input stream
+ * @return RationalCurve object
+ */
+template <typename T> RationalCurve<T> curveReadOBJ(std::istream &is)
+{
+    RationalCurve<T> crv;
+    std::vector<glm::vec<3, T>> control_points;
+    bool rat;
+    internal::curveReadOBJ(is, crv.degree, crv.knots, crv.control_points, crv.weights, rat);
+    return crv;
+}
+
+/**
+ * Read surface data from a Wavefront OBJ stream and populate a RationalSurface object
+ * @param is The input stream
+ * @return RationalSurface object
+ */
+template <typename T> RationalSurface<T> surfaceReadOBJ(std::istream &is)
+{
+    RationalSurface<T> srf;
+    bool rat;
+    internal::surfaceReadOBJ(is, srf.degree_u, srf.degree_v, srf.knots_u, srf.knots_v,
+                             srf.control_points, srf.weights, rat);
+    return srf;
+}
+
+/**
+ * Save curve data from a Wavefront OBJ stream and populate a RationalSurface object
+ * @param os The output stream
+ * @param Curve object to save
+ */
+template <typename T> void curveSaveOBJ(std::ostream &os, const Curve<T> &crv)
+{
+    std::vector<T> w(crv.control_points.size(), T(1));
+    internal::curveSaveOBJ(os, crv.degree, crv.knots, crv.control_points, w, false);
+}
+
+/**
+ * Save rational curve data to a Wavefront OBJ stream.
+ * @param os The output stream
+ * @param RationalCurve object to save
+ */
+template <typename T> void curveSaveOBJ(std::ostream &os, const RationalCurve<T> &crv)
+{
+    internal::curveSaveOBJ(os, crv.degree, crv.knots, crv.control_points, crv.weights, true);
+}
+
+/**
+ * Save non-rational surface data to a Wavefront OBJ stream.
+ * @param os The output stream
+ * @param srf Surface object to save
+ */
+template <typename T> void surfaceSaveOBJ(std::ostream &os, const Surface<T> &srf)
+{
+    array2<T> w(srf.control_points.rows(), srf.control_points.cols(), T(1));
+    internal::surfaceSaveOBJ(os, srf.degree_u, srf.degree_v, srf.knots_u, srf.knots_v,
+                             srf.control_points, w, false);
+}
+
+/**
+ * Save rational surface data to a Wavefront OBJ stream.
+ * @param os The output stream
+ * @param srf RationalSurface object to save
+ */
+template <typename T>
+void surfaceSaveOBJ(std::ostream &os, const RationalSurface<T> &srf)
+{
+    internal::surfaceSaveOBJ(os, srf.degree_u, srf.degree_v, srf.knots_u, srf.knots_v,
+                             srf.control_points, srf.weights, true);
+}
 
 /////////////////////////////////////////////////////////////////////
 
@@ -508,11 +565,13 @@ void surfaceSaveOBJ(const std::string &filename, unsigned int deg_u, unsigned in
  */
 template <typename T> RationalCurve<T> curveReadOBJ(const std::string &filename)
 {
-    RationalCurve<T> crv;
-    std::vector<glm::vec<3, T>> control_points;
-    bool rat;
-    internal::curveReadOBJ(filename, crv.degree, crv.knots, crv.control_points, crv.weights, rat);
-    return crv;
+    std::ifstream file(filename);
+    if (!file)
+    {
+        throw std::runtime_error("File not found: " + filename);
+    }
+
+    return curveReadOBJ<T>(file);
 }
 
 /**
@@ -522,11 +581,13 @@ template <typename T> RationalCurve<T> curveReadOBJ(const std::string &filename)
  */
 template <typename T> RationalSurface<T> surfaceReadOBJ(const std::string &filename)
 {
-    RationalSurface<T> srf;
-    bool rat;
-    internal::surfaceReadOBJ(filename, srf.degree_u, srf.degree_v, srf.knots_u, srf.knots_v,
-                             srf.control_points, srf.weights, rat);
-    return srf;
+    std::ifstream file(filename);
+    if (!file)
+    {
+        throw std::runtime_error("File not found: " + filename);
+    }
+
+    return surfaceReadOBJ<T>(file);
 }
 
 /**
@@ -536,8 +597,8 @@ template <typename T> RationalSurface<T> surfaceReadOBJ(const std::string &filen
  */
 template <typename T> void curveSaveOBJ(const std::string &filename, const Curve<T> &crv)
 {
-    std::vector<T> w(crv.control_points.size(), T(1));
-    internal::curveSaveOBJ(filename, crv.degree, crv.knots, crv.control_points, w, false);
+    std::ofstream fout(filename);
+    curveSaveOBJ(fout, crv);
 }
 
 /**
@@ -547,7 +608,8 @@ template <typename T> void curveSaveOBJ(const std::string &filename, const Curve
  */
 template <typename T> void curveSaveOBJ(const std::string &filename, const RationalCurve<T> &crv)
 {
-    internal::curveSaveOBJ(filename, crv.degree, crv.knots, crv.control_points, crv.weights, true);
+    std::ofstream fout(filename);
+    curveSaveOBJ(fout, crv);
 }
 
 /**
@@ -557,9 +619,8 @@ template <typename T> void curveSaveOBJ(const std::string &filename, const Ratio
  */
 template <typename T> void surfaceSaveOBJ(const std::string &filename, const Surface<T> &srf)
 {
-    array2<T> w(srf.control_points.rows(), srf.control_points.cols(), T(1));
-    internal::surfaceSaveOBJ(filename, srf.degree_u, srf.degree_v, srf.knots_u, srf.knots_v,
-                             srf.control_points, w, false);
+    std::ofstream fout(filename);
+    surfaceSaveOBJ(fout, srf);
 }
 
 /**
@@ -570,8 +631,8 @@ template <typename T> void surfaceSaveOBJ(const std::string &filename, const Sur
 template <typename T>
 void surfaceSaveOBJ(const std::string &filename, const RationalSurface<T> &srf)
 {
-    internal::surfaceSaveOBJ(filename, srf.degree_u, srf.degree_v, srf.knots_u, srf.knots_v,
-                             srf.control_points, srf.weights, true);
+    std::ofstream fout(filename);
+    surfaceSaveOBJ(fout, srf);
 }
 
 } // namespace tinynurbs


### PR DESCRIPTION
It is better to do IO on istream and ostream instead taking a filepath and opening an fstream.
This way the caller has more flexibility on how to handle it's streams.

These changes allow writing to streams like std::cout or std::stringstream.

Care is taken to keep backwards compatibility with existing code.
A seperate file is introduced `objstream.h` that does not include the `<fstream>` header.