### PR TITLE
 Fix the computation of knot multiplicity (issue #10) 

### DIFF
--- a/include/tinynurbs/core/check.h
+++ b/include/tinynurbs/core/check.h
@@ -258,7 +258,7 @@ template <typename T> unsigned int knotMultiplicity(const std::vector<T> &knots,
     T u = knots[index];
     T eps = std::numeric_limits<T>::epsilon();
     unsigned int mult = 1;
-    for (unsigned int i = index; i < knots.size(); ++i)
+    for (unsigned int i = index; i < knots.size() - 1; ++i)
     {
         if (std::abs(u - knots[i + 1]) < eps)
         {

--- a/include/tinynurbs/core/check.h
+++ b/include/tinynurbs/core/check.h
@@ -257,10 +257,10 @@ template <typename T> unsigned int knotMultiplicity(const std::vector<T> &knots,
 {
     T u = knots[index];
     T eps = std::numeric_limits<T>::epsilon();
-    unsigned int mult = 0;
+    unsigned int mult = 1;
     for (unsigned int i = index; i < knots.size(); ++i)
     {
-        if (std::abs(u - knots[index + 1]) < eps)
+        if (std::abs(u - knots[i + 1]) < eps)
         {
             ++mult;
         }


### PR DESCRIPTION
The for-loop counting the same knot values did not use its incremented value. The for-loop was also updated accordingly to not exceed the vector size. Finally, since the loop counts the number of relations (and not occurrences), the multiplicity is initialized to 1.