### PR TITLE
Follow up fixes after knot multiplicity fix in #11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Other
+build/*

--- a/include/tinynurbs/core/basis.h
+++ b/include/tinynurbs/core/basis.h
@@ -26,6 +26,7 @@ template <typename T> int findSpan(unsigned int degree, const std::vector<T> &kn
 {
     // index of last control point
     int n = static_cast<int>(knots.size()) - degree - 2;
+    assert(n >= 0);
     /*
         // For u that is equal to last knot value
         if (util::close(u, knots[n + 1])) {

--- a/include/tinynurbs/core/check.h
+++ b/include/tinynurbs/core/check.h
@@ -247,11 +247,11 @@ template <typename T> bool isArray2ClosedV(unsigned int degree_v, const array2<T
 /////////////////////////////////////////////////////////////////////
 
 /**
- * Returns the mulitplicity of the knot at index
+ * Returns the multiplicity of the knot at index
  * @tparam Type of knot values
  * @param[in] knots Knot vector
- * @param[in] index Index of knot of interest
- * @return Multiplicity (>= 1)
+ * @param[in] knot_val Knot of interest
+ * @return Multiplicity (>= 0)
  */
 template <typename T> unsigned int knotMultiplicity(const std::vector<T> &knots, T knot_val)
 {

--- a/include/tinynurbs/core/check.h
+++ b/include/tinynurbs/core/check.h
@@ -253,14 +253,37 @@ template <typename T> bool isArray2ClosedV(unsigned int degree_v, const array2<T
  * @param[in] index Index of knot of interest
  * @return Multiplicity (>= 1)
  */
-template <typename T> unsigned int knotMultiplicity(const std::vector<T> &knots, unsigned int index)
+template <typename T> unsigned int knotMultiplicity(const std::vector<T> &knots, T knot_val)
 {
-    T u = knots[index];
     T eps = std::numeric_limits<T>::epsilon();
-    unsigned int mult = 1;
-    for (unsigned int i = index; i < knots.size() - 1; ++i)
+    unsigned int mult = 0;
+    for (const T knot : knots)
     {
-        if (std::abs(u - knots[i + 1]) < eps)
+        if (std::abs(knot_val - knot) < eps)
+        {
+            ++mult;
+        }
+    }
+    return mult;
+}
+
+/**
+ * Returns the mulitplicity of the knot at index
+ * @tparam Type of knot values
+ * @param[in] knots Knot vector
+ * @param[in] index Index of knot of interest
+ * @return Multiplicity (>= 1)
+ */
+template <typename T>
+[[deprecated("Use knotMultiplicity(knots, param).")]]
+unsigned int knotMultiplicity(const std::vector<T> &knots, unsigned int index)
+{
+    T curr_knot_val = knots[index];
+    T eps = std::numeric_limits<T>::epsilon();
+    unsigned int mult = 0;
+    for (const T knot : knots)
+    {
+        if (std::abs(curr_knot_val - knot) < eps)
         {
             ++mult;
         }

--- a/include/tinynurbs/core/modify.h
+++ b/include/tinynurbs/core/modify.h
@@ -44,6 +44,8 @@ void curveKnotInsert(unsigned int deg, const std::vector<T> &knots,
     assert(s <= deg); // Multiplicity cannot be greater than degree
     if (s == deg)
     {
+        new_knots = knots;
+        new_cp = cp;
         return;
     }
     if ((r + s) > deg)
@@ -122,6 +124,8 @@ void surfaceKnotInsert(unsigned int degree, const std::vector<T> &knots,
     assert(s <= degree);  // Knot multiplicity cannot be greater than degree
     if (s == degree)
     {
+        new_cp = cp;
+        new_knots = knots;
         return;
     }
     if ((r + s) > degree)

--- a/include/tinynurbs/core/modify.h
+++ b/include/tinynurbs/core/modify.h
@@ -40,7 +40,8 @@ void curveKnotInsert(unsigned int deg, const std::vector<T> &knots,
                      std::vector<T> &new_knots, std::vector<glm::vec<dim, T>> &new_cp)
 {
     int k = findSpan(deg, knots, u);
-    unsigned int s = knotMultiplicity(knots, k);
+    unsigned int s = knotMultiplicity(knots, u);
+    assert(s <= deg); // Multiplicity cannot be greater than degree
     if (s == deg)
     {
         return;
@@ -50,7 +51,7 @@ void curveKnotInsert(unsigned int deg, const std::vector<T> &knots,
         r = deg - s;
     }
 
-    // Insert new knots between span and (span + 1)
+    // Insert new knots between k and (k + 1)
     new_knots.resize(knots.size() + r);
     for (int i = 0; i < k + 1; ++i)
     {
@@ -117,7 +118,8 @@ void surfaceKnotInsert(unsigned int degree, const std::vector<T> &knots,
                        std::vector<T> &new_knots, array2<glm::vec<dim, T>> &new_cp)
 {
     int span = findSpan(degree, knots, knot);
-    unsigned int s = knotMultiplicity(knots, span);
+    unsigned int s = knotMultiplicity(knots, knot);
+    assert(s <= degree);  // Knot multiplicity cannot be greater than degree
     if (s == degree)
     {
         return;
@@ -262,7 +264,7 @@ void curveSplit(unsigned int degree, const std::vector<T> &knots,
     std::vector<glm::vec<dim, T>> tmp_cp;
 
     int span = findSpan(degree, knots, u);
-    int r = degree - knotMultiplicity(knots, span);
+    int r = degree - knotMultiplicity(knots, u);
 
     internal::curveKnotInsert(degree, knots, control_points, u, r, tmp_knots, tmp_cp);
 
@@ -320,7 +322,7 @@ void surfaceSplit(unsigned int degree, const std::vector<T> &knots,
     array2<glm::vec<dim, T>> tmp_cp;
 
     int span = findSpan(degree, knots, param);
-    unsigned int r = degree - knotMultiplicity(knots, span);
+    unsigned int r = degree - knotMultiplicity(knots, param);
     internal::surfaceKnotInsert(degree, knots, control_points, param, r, along_u, tmp_knots,
                                 tmp_cp);
 

--- a/tests/test_curve.cpp
+++ b/tests/test_curve.cpp
@@ -29,7 +29,7 @@ TEST_CASE("curvePoint (non-rational)", "[curve, non-rational, evaluate]")
     REQUIRE(pt2.y == Approx(0));
 }
 
-TEST_CASE("curveTangent (glm::vec2)", "[curve, glm::vec2, evaluate]")
+TEST_CASE("curveTangent (glm::vec2)", "[curve, non-rational, evaluate]")
 {
     auto crv = getNonrationalBezierCurve();
     glm::vec2 tgt1 = tinynurbs::curveTangent(crv, 0.5f);
@@ -37,7 +37,7 @@ TEST_CASE("curveTangent (glm::vec2)", "[curve, glm::vec2, evaluate]")
     REQUIRE(tgt1.y == Approx(0));
 }
 
-TEST_CASE("curveIsValid (non-rational)", "[curve, glm::vec2, check]")
+TEST_CASE("curveIsValid (non-rational)", "[curve, non-rational, check]")
 {
     auto crv = getNonrationalBezierCurve();
     bool is_valid = tinynurbs::curveIsValid(crv);
@@ -49,13 +49,29 @@ TEST_CASE("curveIsValid (non-rational)", "[curve, glm::vec2, check]")
     REQUIRE(is_valid == false);
 }
 
-TEST_CASE("curveKnotMultiplicity (non-rational)", "[curve, glm::vec2, basis]")
+TEST_CASE("curveKnotMultiplicity (non-rational)", "[knots, check]")
 {
-    auto crv = getNonrationalBezierCurve();
-    unsigned int knotMult0 = tinynurbs::knotMultiplicity(crv.knots, 0.0);
-    REQUIRE(knotMult0 == 3);
-    unsigned int knotMult1 = tinynurbs::knotMultiplicity(crv.knots, 1.0);
-    REQUIRE(knotMult1 == 3);
+    {
+        const std::vector<float> knots{0.0, 0.0, 0.0, 1.0, 1.0};
+        unsigned int knotMult0 = tinynurbs::knotMultiplicity(knots, 0.0);
+        REQUIRE(knotMult0 == 3);
+        unsigned int knotMult1 = tinynurbs::knotMultiplicity(knots, 1.0);
+        REQUIRE(knotMult1 == 2);
+    }
+    {
+        const std::vector<float> knots{0.0, 1.0};
+        unsigned int knotMult0 = tinynurbs::knotMultiplicity(knots, 0.0);
+        REQUIRE(knotMult0 == 1);
+        unsigned int knotMult1 = tinynurbs::knotMultiplicity(knots, 1.0);
+        REQUIRE(knotMult1 == 1);
+    }
+    {
+        const std::vector<float> knots{0.0, 0.0001, 0.0002, 1.0, 1.0001};
+        unsigned int knotMult0 = tinynurbs::knotMultiplicity(knots, 0.0);
+        REQUIRE(knotMult0 == 1);
+        unsigned int knotMult1 = tinynurbs::knotMultiplicity(knots, 1.0);
+        REQUIRE(knotMult1 == 1);
+    }
 }
 
 TEST_CASE("curveInsertKnot (non-rational)", "[curve, non-rational, modify]")

--- a/tests/test_curve.cpp
+++ b/tests/test_curve.cpp
@@ -49,6 +49,15 @@ TEST_CASE("curveIsValid (non-rational)", "[curve, glm::vec2, check]")
     REQUIRE(is_valid == false);
 }
 
+TEST_CASE("curveKnotMultiplicity (non-rational)", "[curve, glm::vec2, basis]")
+{
+    auto crv = getNonrationalBezierCurve();
+    unsigned int knotMult0 = tinynurbs::knotMultiplicity(crv.knots, 0.0);
+    REQUIRE(knotMult0 == 3);
+    unsigned int knotMult1 = tinynurbs::knotMultiplicity(crv.knots, 1.0);
+    REQUIRE(knotMult1 == 3);
+}
+
 TEST_CASE("curveInsertKnot (non-rational)", "[curve, non-rational, modify]")
 {
     auto crv = getNonrationalBezierCurve();

--- a/tests/test_curve.cpp
+++ b/tests/test_curve.cpp
@@ -52,21 +52,21 @@ TEST_CASE("curveIsValid (non-rational)", "[curve, non-rational, check]")
 TEST_CASE("curveKnotMultiplicity (non-rational)", "[knots, check]")
 {
     {
-        const std::vector<float> knots{0.0, 0.0, 0.0, 1.0, 1.0};
+        const std::vector<double> knots{0.0, 0.0, 0.0, 1.0, 1.0};
         unsigned int knotMult0 = tinynurbs::knotMultiplicity(knots, 0.0);
         REQUIRE(knotMult0 == 3);
         unsigned int knotMult1 = tinynurbs::knotMultiplicity(knots, 1.0);
         REQUIRE(knotMult1 == 2);
     }
     {
-        const std::vector<float> knots{0.0, 1.0};
+        const std::vector<double> knots{0.0, 1.0};
         unsigned int knotMult0 = tinynurbs::knotMultiplicity(knots, 0.0);
         REQUIRE(knotMult0 == 1);
         unsigned int knotMult1 = tinynurbs::knotMultiplicity(knots, 1.0);
         REQUIRE(knotMult1 == 1);
     }
     {
-        const std::vector<float> knots{0.0, 0.0001, 0.0002, 1.0, 1.0001};
+        const std::vector<double> knots{0.0, 0.0001, 0.0002, 1.0, 1.0001};
         unsigned int knotMult0 = tinynurbs::knotMultiplicity(knots, 0.0);
         REQUIRE(knotMult0 == 1);
         unsigned int knotMult1 = tinynurbs::knotMultiplicity(knots, 1.0);


### PR DESCRIPTION
After merging #11, a few other problems were revealed and this PR fixes them.

- Add unit test for knot multiplicity
- Add a function `knotMultiplicity(knots, knot)` that takes in the knot value rather than the span as the second argument. `knotMultiplicity(knots, index)` is deprecated.
- Fix a bug where `curveKnotInsert` and `surfaceKnotInsert` would return empty knots and control points if the knot multiplicity is already at the maximum.