### PR TITLE
Fix Infinite Loop in findSpan Method by Using std::lower_bound

### DIFF
--- a/include/tinynurbs/core/basis.h
+++ b/include/tinynurbs/core/basis.h
@@ -40,22 +40,8 @@ template <typename T> int findSpan(unsigned int degree, const std::vector<T> &kn
 
     // Binary search
     // TODO: Replace this with std::lower_bound
-    int low = degree;
-    int high = n + 1;
-    int mid = (int)std::floor((low + high) / 2.0);
-    while (u < knots[mid] || u >= knots[mid + 1])
-    {
-        if (u < knots[mid])
-        {
-            high = mid;
-        }
-        else
-        {
-            low = mid;
-        }
-        mid = (int)std::floor((low + high) / 2.0);
-    }
-    return mid;
+    auto it = std::lower_bound(knots.begin() + degree, knots.begin() + n + 2, u);
+    return static_cast<int>(it - knots.begin()) - 1;
 }
 
 /**


### PR DESCRIPTION
This pull request addresses an issue in the findSpan method where, under certain conditions, the method could enter an infinite loop during the binary search process.

The primary change involves replacing the custom binary search implementation with the standard std::lower_bound function from the C++ Standard Library. This change not only prevents the infinite loop but also simplifies the code and improves robustness.